### PR TITLE
chore: update repository URL and dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "@elizaos/plugin-sicklegraph",
       "dependencies": {
-        "@elizaos/cli": "beta",
+        "@elizaos/cli": "1.0.0-beta.52",
         "@elizaos/core": "beta",
         "@elizaos/plugin-bootstrap": "^1.0.0-beta.51",
         "@elizaos/plugin-groq": "beta",
@@ -43,7 +43,7 @@
 
     "@electric-sql/pglite": ["@electric-sql/pglite@0.2.17", "", {}, "sha512-qEpKRT2oUaWDH6tjRxLHjdzMqRUGYDnGZlKrnL4dJ77JVMcP2Hpo3NYnOSPKdZdeec57B6QPprCUFg0picx5Pw=="],
 
-    "@elizaos/cli": ["@elizaos/cli@1.0.0-beta.51", "", { "dependencies": { "@electric-sql/pglite": "^0.2.17", "@elizaos/core": "^1.0.0-beta.51", "@elizaos/plugin-sql": "^1.0.0-beta.51", "bun": "^1.2.13", "path-to-regexp": "^8.2.0", "socket.io": "^4.8.1", "zod": "3.24.2" }, "bin": { "elizaos": "dist/index.js" } }, "sha512-oHUEjkUquqIHXMWkOlfhXTxAn5SUfRw3+FVkueG44ptGhxMFzeVKW5gUAg7MFiY4NtaZiaFkvZ3mlOG7uYy+9g=="],
+    "@elizaos/cli": ["@elizaos/cli@1.0.0-beta.52", "", { "dependencies": { "@electric-sql/pglite": "^0.2.17", "@elizaos/core": "^1.0.0-beta.52", "@elizaos/plugin-sql": "^1.0.0-beta.52", "bun": "^1.2.13", "path-to-regexp": "^8.2.0", "socket.io": "^4.8.1", "zod": "3.24.2" }, "bin": { "elizaos": "dist/index.js" } }, "sha512-4RGS3eoIpfHAXpA8FCYNcFg+OyqftAcXkDjrmPmwCxA0EEywQLA26yee5RGUHwR+DCiJ+vJcA+mT5tzXumLZ1Q=="],
 
     "@elizaos/core": ["@elizaos/core@1.0.0-beta.51", "", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/exporter-trace-otlp-http": "^0.53.0", "@opentelemetry/instrumentation-pg": "^0.52.0", "@opentelemetry/sdk-metrics": "^1.26.0", "@opentelemetry/sdk-node": "^0.53.0", "buffer": "^6.0.3", "crypto-browserify": "^3.12.1", "dotenv": "16.4.5", "events": "^3.3.0", "glob": "11.0.0", "handlebars": "^4.7.8", "js-sha1": "0.7.0", "langchain": "^0.3.15", "pino": "^9.6.0", "pino-pretty": "^13.0.0", "stream-browserify": "^3.0.0", "unique-names-generator": "4.7.1", "uuid": "11.0.3" } }, "sha512-BcNhARMfMkDgeTke8VDTg2Mkad+nM3ZcA0OzZeMrXDCEBlXw6cBV2Un3HrEuz1pcaTAH6aq0Rxgj/lf/RvpMwQ=="],
 
@@ -884,6 +884,10 @@
     "zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.24.5", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g=="],
+
+    "@elizaos/cli/@elizaos/core": ["@elizaos/core@1.0.0-beta.52", "", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/exporter-trace-otlp-http": "^0.53.0", "@opentelemetry/instrumentation-pg": "^0.52.0", "@opentelemetry/sdk-metrics": "^1.26.0", "@opentelemetry/sdk-node": "^0.53.0", "buffer": "^6.0.3", "crypto-browserify": "^3.12.1", "dotenv": "16.4.5", "events": "^3.3.0", "glob": "11.0.0", "handlebars": "^4.7.8", "js-sha1": "0.7.0", "langchain": "^0.3.15", "pino": "^9.6.0", "pino-pretty": "^13.0.0", "stream-browserify": "^3.0.0", "unique-names-generator": "4.7.1", "uuid": "11.0.3" } }, "sha512-A6YbJiKF3WbcAKQG6e3eC9sG8Dc1vTVUV1PZgJJFLErk2KuetTFSO3bs7OoNgvnTJfILd/8r44ig6kpPYe+FDA=="],
+
+    "@elizaos/cli/@elizaos/plugin-sql": ["@elizaos/plugin-sql@1.0.0-beta.52", "", { "dependencies": { "@electric-sql/pglite": "^0.2.17", "@elizaos/core": "^1.0.0-beta.52", "@types/pg": "8.11.10", "drizzle-kit": "^0.30.4", "drizzle-orm": "^0.39.1", "pg": "^8.13.3" }, "peerDependencies": { "typescript": "5.8.2", "whatwg-url": "7.1.0" } }, "sha512-wEZ+qoT9s+l1bejQ1cQlOzpMs4o2k2jeYpyO5szUMpnN+XbCnQDDOUwTzNa4ZwVk5of4Kftjrc0d6FCEwQK1qA=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "github:elizaos/plugin-sicklegraph"
+    "url": "github:jasonviipers/plugin-sicklegraph"
   },
   "exports": {
     "./package.json": "./package.json",
@@ -28,7 +28,7 @@
     "dist"
   ],
   "dependencies": {
-    "@elizaos/cli": "beta",
+    "@elizaos/cli": "1.0.0-beta.52",
     "@elizaos/core": "beta",
     "@elizaos/plugin-bootstrap": "^1.0.0-beta.51",
     "@elizaos/plugin-groq": "beta",


### PR DESCRIPTION
Update the repository URL from `github:elizaos/plugin-sicklegraph` to `github:jasonviipers/plugin-sicklegraph`. Also, update the dependency `@elizaos/cli` from `beta` to `1.0.0-beta.52` to ensure compatibility and stability.

## Summary by Sourcery

Update the repository URL and upgrade the @elizaos/cli dependency to ensure compatibility and stability

Enhancements:
- Update repository URL to github:jasonviipers/plugin-sicklegraph
- Bump @elizaos/cli dependency from beta to 1.0.0-beta.52 for improved compatibility